### PR TITLE
added forcePullImage=true in Chronos Job

### DIFF
--- a/lib/galaxy/jobs/runners/pymesos.py
+++ b/lib/galaxy/jobs/runners/pymesos.py
@@ -469,7 +469,8 @@ class PyMesosJobRunner(AsynchronousJobRunner):
               "container": {
                 "type": "DOCKER",
                 "image":docker_image, # self._find_container(job_wrapper).container_id,
-                "volumes": volumes
+                "volumes": volumes,
+                "forcePullImage":True 
               },
               "successCount": 0,
               "errorCount": 0, 


### PR DESCRIPTION
If a new image is needed in a mesos slave "forcePullImage=true"  avoid user do it by command line before sending Chronos job